### PR TITLE
Fix forecast sectiion

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -106,9 +106,9 @@ function App() {
     console.log(city);
     if(city !== ""){
     fetch(
-      "https://api.openweathermap.org/data/2.5/forecast/daily?q=" +
+      "https://pro.openweathermap.org/data/2.5/forecast/climate?q=" +
         city +
-        "&units=metric&cnt=7&appid=" +
+        "&appid=" +
         process.env.REACT_APP_APIKEY
     )
       .then((res) => {

--- a/src/App.js
+++ b/src/App.js
@@ -21,9 +21,8 @@ import {
 } from "react-simple-maps";
 import ReactTooltip from "react-tooltip";
 import changeBackground from './utils/changeBackground';
-import Forecast from "./Components/Forecast/Forecast"
 
-// import ForecastCard from "./Components/Forecast/ForecastCard";
+import ForecastCard from "./Components/Forecast/ForecastCard";
 import Footer from "./Components/Footer/Footer";
 import AQIPollution from "./Components/AQIPollutionRate/AQIPollution";
 
@@ -104,6 +103,8 @@ function App() {
   const [data, setData] = useState(null);
   const [filterInput, setFilterInput]=useState("");
    useEffect(() => {
+    console.log(city);
+    if(city !== ""){
     fetch(
       "https://api.openweathermap.org/data/2.5/forecast/daily?q=" +
         city +
@@ -119,6 +120,7 @@ function App() {
         setData(resp);
         console.log("data", data);
       });
+    }
   }, [city]);
 
   useEffect(() => {
@@ -333,8 +335,10 @@ function App() {
   //useEffect hook for updating the city 
   //based on the member's location selected in the filter.
   useEffect(()=>{
+    if(filterInput !== ""){
     const filteredPlace = filterInput.value
     setCity(filteredPlace)
+    }
   },[filterInput])
 
 
@@ -424,10 +428,12 @@ function App() {
               </>
             )}
           </div>
-          <div className = "forecast-container" id = "forecast-wrapper">
+          {/* <div className = "forecast-container" id = "forecast-wrapper">
+           { 
             <Forecast results = {results}/>
-          </div>
-        
+           }
+            </div>
+         */}
         </div>
         {activities && (
           <div>
@@ -444,13 +450,17 @@ function App() {
         <div>
           <h1> Weather Globe </h1>
         </div>
-        <span style={{ display: "inline-block", padding: "0px 10px" }}>
+        <span style={{ display: "inline-block", padding: "0px 0px" , height:"20vh",width:"80%", justifyContent: "center" , alignContent:"center"}}>
           <MyGlobe
             setCountry={setCountryCode}
             setCity={setCity}
             setInput={setInputValue}
           />
         </span>
+        { (data !== undefined &&
+            data !== null &&
+            results !== undefined &&
+            results !== null) && (<> <ForecastCard data={data} results={results} /> </>)}
         <div className="mapContainer">
           <h1> Global Weather Map </h1>
           <ReactTooltip>{content}</ReactTooltip>

--- a/src/Components/Forecast/ForecastCard.css
+++ b/src/Components/Forecast/ForecastCard.css
@@ -1,6 +1,7 @@
 .main-block {
-  padding-bottom: 20px;
-}
+    display: flex;
+    flex-direction: column;
+  }
 
 .forecast-section-header {
   margin-top: 15px;

--- a/src/Components/Forecast/ForecastCard.css
+++ b/src/Components/Forecast/ForecastCard.css
@@ -1,3 +1,17 @@
+.show-more-section {
+  text-align: center;
+  padding: 20px;
+}
+
+.show-more {
+  border: none;
+  background-color: rgb(35, 35, 35);
+  color: white;
+  height: 50px;
+  width: 200px;
+  border-radius: 5px;
+}
+
 .main-block {
     display: flex;
     flex-direction: column;

--- a/src/Components/Forecast/ForecastCard.js
+++ b/src/Components/Forecast/ForecastCard.js
@@ -15,8 +15,6 @@ const ForecastCard = ({data, results}) => {
       setMore(more+7);
     };
 
-    const [isShown, setIsShown] = useState(false);
-
     const getImage = (e) => {
         if(e === "Clear") {
             return "https://img.icons8.com/emoji/96/000000/sun-emoji.png"
@@ -53,10 +51,7 @@ const ForecastCard = ({data, results}) => {
       } else {
 
     return <>
-        <div  className="main-block"
-         onMouseEnter={() => setIsShown(true)}
-         onMouseLeave={() => setIsShown(false)}
-         >
+        <div  className="main-block">
             <h3 className="forecast-section-header">Weekly Forecast for {results.name}</h3>
             <div className="car-block">
               {
@@ -68,7 +63,6 @@ const ForecastCard = ({data, results}) => {
                             <div>{currentDate(e.dt)}</div>
                             <div className="temp">{Math.round(`${toCelsius(`${e.feels_like.day}`)}`, -1)}°C</div>
                             <div className="desc">{`${e.weather[0].description}`.toUpperCase()}</div>
-                            {isShown && e.dt &&(
                             <ul className="details">
                                 <li>
                                     <div>Cloudiness {e.clouds}%</div>
@@ -86,7 +80,6 @@ const ForecastCard = ({data, results}) => {
                                     <div>Max temp {Math.round(`${toCelsius(`${e.temp.max}`)}`, -1)}°C</div>
                                 </li>
                             </ul>
-                            )}
                         </div>
                     </div>
                 )).slice(0, more)

--- a/src/Components/Forecast/ForecastCard.js
+++ b/src/Components/Forecast/ForecastCard.js
@@ -9,9 +9,11 @@ const ForecastCard = ({data, results}) => {
           
     },[]);
 
-    // const toCelsius = (el) => {
-    //     return el-273.15;
-    // }
+    const [more, setMore] = useState(7);
+    const showMore = (e) => {
+      e.preventDefault();
+      setMore(more+7);
+    };
 
     const getImage = (e) => {
         if(e === "Clear") {
@@ -27,6 +29,10 @@ const ForecastCard = ({data, results}) => {
         }
     };
 
+    const toCelsius = (el) => {
+        return el-273.15;
+    }    
+
     const weekDay = (e) => {
         let unix_timestamp = e;
         var date = new Date(unix_timestamp * 1000).toLocaleString('en-us', {weekday:'long'});
@@ -38,10 +44,8 @@ const ForecastCard = ({data, results}) => {
         let unix_timestamp = e;
         var s = new Date(unix_timestamp * 1000).toLocaleDateString("en-UK");
         return s;
-    }
+    };
 
-
-    
     if (error) {
         return <div>Error: {error.message}</div>;
       } else {
@@ -57,7 +61,7 @@ const ForecastCard = ({data, results}) => {
                             <img className="icon" src={getImage(e.weather[0].main)} alt="weather-icon"/>
                             <div>{weekDay(e.dt)}</div>
                             <div>{currentDate(e.dt)}</div>
-                            <div className="temp">{Math.round(`${e.feels_like.day}`, -1)}°C</div>
+                            <div className="temp">{Math.round(`${toCelsius(`${e.feels_like.day}`)}`, -1)}°C</div>
                             <div className="desc">{`${e.weather[0].description}`.toUpperCase()}</div>
                             <ul className="details">
                                 <li>
@@ -70,16 +74,21 @@ const ForecastCard = ({data, results}) => {
                                     <div>Humidity {e.humidity}%</div>
                                 </li>
                                 <li className="min-max">
-                                    <div>Min temp {Math.round(`${e.temp.min}`, -1)}°C</div>
+                                    <div>Min temp {Math.round(`${toCelsius(`${e.temp.min}`)}`, -1)}°C</div>
                                 </li>
                                 <li>
-                                    <div>Max temp {Math.round(`${e.temp.max}`, -1)}°C</div>
+                                    <div>Max temp {Math.round(`${toCelsius(`${e.temp.max}`)}`, -1)}°C</div>
                                 </li>
                             </ul>
                         </div>
                     </div>
-                ))
+                )).slice(0, more)
                 }
+            </div>
+            <div className="show-more-section">
+                <button onClick={showMore} className="show-more">
+                Show more days
+                </button>
             </div>
         </div>
     </>

--- a/src/Components/Forecast/ForecastCard.js
+++ b/src/Components/Forecast/ForecastCard.js
@@ -15,6 +15,8 @@ const ForecastCard = ({data, results}) => {
       setMore(more+7);
     };
 
+    const [isShown, setIsShown] = useState(false);
+
     const getImage = (e) => {
         if(e === "Clear") {
             return "https://img.icons8.com/emoji/96/000000/sun-emoji.png"
@@ -51,7 +53,10 @@ const ForecastCard = ({data, results}) => {
       } else {
 
     return <>
-        <div  className="main-block">
+        <div  className="main-block"
+         onMouseEnter={() => setIsShown(true)}
+         onMouseLeave={() => setIsShown(false)}
+         >
             <h3 className="forecast-section-header">Weekly Forecast for {results.name}</h3>
             <div className="car-block">
               {
@@ -63,6 +68,7 @@ const ForecastCard = ({data, results}) => {
                             <div>{currentDate(e.dt)}</div>
                             <div className="temp">{Math.round(`${toCelsius(`${e.feels_like.day}`)}`, -1)}°C</div>
                             <div className="desc">{`${e.weather[0].description}`.toUpperCase()}</div>
+                            {isShown && e.dt &&(
                             <ul className="details">
                                 <li>
                                     <div>Cloudiness {e.clouds}%</div>
@@ -80,6 +86,7 @@ const ForecastCard = ({data, results}) => {
                                     <div>Max temp {Math.round(`${toCelsius(`${e.temp.max}`)}`, -1)}°C</div>
                                 </li>
                             </ul>
+                            )}
                         </div>
                     </div>
                 )).slice(0, more)

--- a/src/Components/Forecast/ForecastCard.js
+++ b/src/Components/Forecast/ForecastCard.js
@@ -87,7 +87,7 @@ const ForecastCard = ({data, results}) => {
             </div>
             <div className="show-more-section">
                 <button onClick={showMore} className="show-more">
-                Show more days
+                More days forecast
                 </button>
             </div>
         </div>

--- a/src/Components/globe_model.js
+++ b/src/Components/globe_model.js
@@ -77,7 +77,7 @@ export default function MyGlobe({setCountry,setCity,setInput}) {
         height="70vh"
         markers={markers}
         options={options}
-        width="30vw"
+        width="100%"
         onClickMarker={onClickMarker}
         onDefocus={onDefocus}
       />


### PR DESCRIPTION
In this PR was made:

- Fixed the issue of undefined or null fetching data from [30 days forecast API](https://openweathermap.org/api/forecast30)
- Fixed the city changing condition for rendering the fetching data
- Added the possibility to click on the Show more button and display the next week of the forecast, till the 30 days fulfilled in the Forecast section

> The screenshot for newly implemented functionality:
<img width="1420" alt="Screen Shot 2022-07-28 at 15 51 25" src="https://user-images.githubusercontent.com/49064106/181498662-25886d99-b594-4dfc-92ba-43c635cf23ab.png">

